### PR TITLE
Set Warehouse::FakeAPI to always use a current employee start date.

### DIFF
--- a/lib/warehouse/fake_api.rb
+++ b/lib/warehouse/fake_api.rb
@@ -89,7 +89,7 @@ module Warehouse
     def self.data
       @created_at ||= Time.parse("2014-01-01 08:50:00 UTC")
       @updated_at ||= Time.parse("2014-01-10 08:50:00 UTC")
-      @start_date ||= Time.parse("#{Time.now.month}/#{Time.now.year}")
+      @start_date ||= Time.parse("#{Time.now.prev_month}/#{Time.now.year}")
       @employments ||= [
         {
           :position =>  {


### PR DESCRIPTION
Warehouse::FakeAPI set the start date to the beginning of the month, meaning on the 1st of the month there will be two failing tests.\n The solution to this is to set the start date to a month ago, meaning the start date will always have been in the past so the employee will always be current for test.